### PR TITLE
Use a vanity import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2022-12-19
+### Changed
+- Change the module path to `go.abhg.dev/goldmark/hashtag`.
+
+[0.3.0]: https://github.com/abhinav/goldmark-hashtag/releases/tag/v0.3.0
+
 ## [0.2.0] - 2022-03-29
 ### Added
 - Add support for Obsidian-compatible hashtags.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/abhinav/goldmark-hashtag.svg)](https://pkg.go.dev/github.com/abhinav/goldmark-hashtag)
+[![Go Reference](https://pkg.go.dev/badge/go.abhg.dev/goldmark/hashtag.svg)](https://pkg.go.dev/go.abhg.dev/goldmark/hashtag)
 [![Go](https://github.com/abhinav/goldmark-hashtag/actions/workflows/go.yml/badge.svg)](https://github.com/abhinav/goldmark-hashtag/actions/workflows/go.yml)
 [![codecov](https://codecov.io/gh/abhinav/goldmark-hashtag/branch/main/graph/badge.svg?token=w6jkI2SQ9u)](https://codecov.io/gh/abhinav/goldmark-hashtag)
 
@@ -12,7 +12,7 @@ support for tagging documents with `#hashtag`s.
 To use goldmark-hashtag, import the `hashtag` package.
 
 ```go
-import hashtag "github.com/abhinav/goldmark-hashtag"
+import "go.abhg.dev/goldmark/hashtag"
 ```
 
 Then include the `hashtag.Extender` in the list of extensions you build your

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/abhinav/goldmark-hashtag
+module go.abhg.dev/goldmark/hashtag
 
 go 1.18
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"testing"
 
-	hashtag "github.com/abhinav/goldmark-hashtag"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/testutil"
+	"go.abhg.dev/goldmark/hashtag"
 )
 
 func TestIntegration_Default(t *testing.T) {
@@ -18,6 +18,7 @@ func TestIntegration_Default(t *testing.T) {
 		t,
 	)
 }
+
 func TestIntegration_Obsidian(t *testing.T) {
 	t.Parallel()
 
@@ -29,6 +30,7 @@ func TestIntegration_Obsidian(t *testing.T) {
 		t,
 	)
 }
+
 func TestIntegration_Resolver(t *testing.T) {
 	t.Parallel()
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/abhinav/goldmark-hashtag/tools
+module go.abhg.dev/goldmark/hashtag/tools
 
 go 1.18
 


### PR DESCRIPTION
Switch to a vanity import path: go.abhg.dev/goldmark/hashtag.
Side-effect: $(basename importpath) now matches the package name.
