### PR TITLE
v0.2: Turn into shim around v0.3

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ '*' ]
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2023-02-11
+### Changed
+- Turn module into a shim around go.abhg.dev/goldmark/hashtag.
+
 ## [0.2.0] - 2022-03-29
 ### Added
 - Add support for Obsidian-compatible hashtags.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,11 @@ golint: $(GOLINT)
 
 .PHONY: staticcheck
 staticcheck: $(STATICCHECK)
-	$(STATICCHECK) ./...
+	$(eval STATICCHECK_LOG := $(shell mktemp -t staticcheck.XXXXX))
+	$(STATICCHECK) ./... | grep -v SA1019 > $(STATICCHECK_LOG) || true
+	@[ ! -s "$(STATICCHECK_LOG)" ] || \
+		(echo "static failed:" | \
+		cat - $(STATICCHECK_LOG) && false)
 
 tools: $(GOLINT) $(STATICCHECK)
 

--- a/ast.go
+++ b/ast.go
@@ -1,24 +1,9 @@
 package hashtag
 
-import "github.com/yuin/goldmark/ast"
+import "go.abhg.dev/goldmark/hashtag"
 
 // Kind is the kind of hashtag AST nodes.
-var Kind = ast.NewNodeKind("Hashtag")
+var Kind = hashtag.Kind
 
 // Node is a hashtag node in a Goldmark Markdown document.
-type Node struct {
-	ast.BaseInline
-
-	// Tag is the portion of the hashtag following the '#'.
-	Tag []byte
-}
-
-// Kind reports the kind of hashtag nodes.
-func (*Node) Kind() ast.NodeKind { return Kind }
-
-// Dump dumps the contents of Node to stdout for debugging.
-func (n *Node) Dump(src []byte, level int) {
-	ast.DumpHelper(n, src, level, map[string]string{
-		"Tag": string(n.Tag),
-	}, nil)
-}
+type Node = hashtag.Node

--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,5 @@
 // Package hashtag provides support for #tag-style tags for the Goldmark
 // Markdown parser.
+//
+// Deprecated: Use go.abhg.dev/goldmark/hashtag instead.
 package hashtag

--- a/extend.go
+++ b/extend.go
@@ -1,57 +1,20 @@
 package hashtag
 
-import (
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/renderer"
-	"github.com/yuin/goldmark/util"
-)
+import "go.abhg.dev/goldmark/hashtag"
 
 // Extender extends a goldmark Markdown object with support for parsing and
 // rendering hashtags.
 //
 // Install it on your Markdown object upon creation.
 //
-//  goldmark.New(
-//    goldmark.WithExtensions(
-//      // ...
-//      &hashtag.Extender{...},
-//    ),
-//    // ...
-//  )
+//	goldmark.New(
+//	  goldmark.WithExtensions(
+//	    // ...
+//	    &hashtag.Extender{...},
+//	  ),
+//	  // ...
+//	)
 //
 // Provide a Resolver to render tags as links that point to a specific
 // destination.
-type Extender struct {
-	// Resolver specifies destination links for hashtags, if any.
-	//
-	// Defaults to no links.
-	Resolver Resolver
-
-	// Variant is the flavor of the hashtag syntax to support.
-	//
-	// Defaults to DefaultVariant. See the documentation of individual
-	// variants for more information.
-	Variant Variant
-}
-
-var _ goldmark.Extender = (*Extender)(nil)
-
-// Extend extends the provided goldmark Markdown object with support for
-// hashtags.
-func (e *Extender) Extend(m goldmark.Markdown) {
-	m.Parser().AddOptions(
-		parser.WithInlineParsers(
-			util.Prioritized(&Parser{
-				Variant: e.Variant,
-			}, 999),
-		),
-	)
-	m.Renderer().AddOptions(
-		renderer.WithNodeRenderers(
-			util.Prioritized(&Renderer{
-				Resolver: e.Resolver,
-			}, 999),
-		),
-	)
-}
+type Extender = hashtag.Extender

--- a/go.mod
+++ b/go.mod
@@ -1,16 +1,18 @@
+// Deprecated: Use "go.abhg.dev/goldmark/hashtag" instead.
 module github.com/abhinav/goldmark-hashtag
 
 go 1.18
 
 require (
-	github.com/forPelevin/gomoji v1.1.3
-	github.com/rivo/uniseg v0.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/yuin/goldmark v1.4.1
+	go.abhg.dev/goldmark/hashtag v0.3.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/forPelevin/gomoji v1.1.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,7 +11,10 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.4.1 h1:/vn0k+RBvwlxEmP5E7SZMqNxPhfMVFEJiykr15/0XKM=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.abhg.dev/goldmark/hashtag v0.3.0 h1:vonmzai7jrBTs3F/n0yirDoOVAdBKOvKdEqpl3Ftd7o=
+go.abhg.dev/goldmark/hashtag v0.3.0/go.mod h1:1Rlxt6roUVx39BN2TCTDpFawujpBPgB9AkBdtCzyUCY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parse.go
+++ b/parse.go
@@ -1,32 +1,16 @@
 package hashtag
 
-import (
-	"bytes"
-	"unicode"
-	"unicode/utf8"
-
-	"github.com/forPelevin/gomoji"
-	"github.com/rivo/uniseg"
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/text"
-)
+import "go.abhg.dev/goldmark/hashtag"
 
 // Parser is a Goldmark inline parser for parsing hashtag nodes.
 //
 // Hashtags start with "#". The list of other characters allowed in the hashtag
 // is determined by variant. See the documentation for Variant for more
 // details.
-type Parser struct {
-	// Variant is the flavor of the hashtag syntax to support.
-	//
-	// Defaults to DefaultVariant. See the documentation of individual
-	// variants for more information.
-	Variant Variant
-}
+type Parser = hashtag.Parser
 
 // Variant represents one of the different flavours of hashtag syntax.
-type Variant uint
+type Variant = hashtag.Variant
 
 const (
 	// DefaultVariant is the default flavor of hashtag syntax supported by
@@ -36,7 +20,7 @@ const (
 	// zero or more alphanumeric characters and the following symbols.
 	//
 	//   /_-
-	DefaultVariant Variant = iota
+	DefaultVariant = hashtag.DefaultVariant
 
 	// ObsidianVariant is a flavor of the hashtag syntax that aims to be
 	// compatible with Obsidian (https://obsidian.md/).
@@ -50,100 +34,5 @@ const (
 	// non-numeric character.
 	//
 	// See also https://help.obsidian.md/How+to/Working+with+tags.
-	ObsidianVariant
+	ObsidianVariant = hashtag.ObsidianVariant
 )
-
-// span returns the index in the provided string at which the hashtag for this
-// variant ends, or -1 if this is not a valid hashtag string.
-//
-// s must be the part of the hashtag *after* the "#".
-func (v Variant) span(tag []byte) int {
-	switch v {
-	case ObsidianVariant:
-		// Tags cannot contain spaces, so if there's a space, that's
-		// the furthest our tag edge can be. This helps avoid trying to
-		// walk the entire string with uniseg.Graphemes.
-		if idx := bytes.IndexFunc(tag, unicode.IsSpace); idx >= 0 {
-			tag = tag[:idx]
-		}
-		end := len(tag)
-
-		gr := uniseg.NewGraphemes(string(tag))
-		for gr.Next() {
-			if endOfObsidianHashtag(gr) {
-				end, _ = gr.Positions()
-				break
-			}
-		}
-
-		// If there isn't at least one non-numeric character,
-		// this isn't a valid tag.
-		if i := bytes.IndexFunc(tag[:end], nonNumeric); i < 0 {
-			return -1
-		}
-
-		return end
-
-	default:
-		// Hashtag must start with a letter.
-		start, sz := utf8.DecodeRune(tag)
-		if !unicode.IsLetter(start) {
-			return -1
-		}
-		tag = tag[sz:]
-
-		// If the end of the tag is visible, that's the end index.
-		// Otherwise, it's the rest of the string.
-		if i := bytes.IndexFunc(tag, endOfHashtag); i >= 0 {
-			return i + sz // (+ first letter)
-		}
-		return len(tag) + sz // (+ first letter)
-	}
-}
-
-var _ parser.InlineParser = (*Parser)(nil)
-
-var _hash = byte('#')
-
-// Trigger reports characters that trigger this parser.
-func (*Parser) Trigger() []byte {
-	return []byte{_hash}
-}
-
-// Parse parses a hashtag node.
-func (p *Parser) Parse(parent ast.Node, block text.Reader, pctx parser.Context) ast.Node {
-	line, seg := block.PeekLine()
-
-	if len(line) == 0 || line[0] != _hash {
-		return nil
-	}
-	line = line[1:]
-
-	end := p.Variant.span(line)
-	if end < 0 {
-		return nil
-	}
-	seg = seg.WithStop(seg.Start + end + 1) // + '#'
-
-	n := Node{
-		Tag: block.Value(seg.WithStart(seg.Start + 1)), // omit the "#"
-	}
-	n.AppendChild(&n, ast.NewTextSegment(seg))
-	block.Advance(seg.Len())
-	return &n
-}
-
-func nonNumeric(r rune) bool {
-	return !unicode.IsDigit(r)
-}
-
-func endOfHashtag(r rune) bool {
-	return !(unicode.IsLetter(r) ||
-		unicode.IsDigit(r) ||
-		r == '_' || r == '-' || r == '/')
-}
-
-func endOfObsidianHashtag(gr *uniseg.Graphemes) bool {
-	rs := gr.Runes()
-	return len(rs) == 1 && endOfHashtag(rs[0]) && !gomoji.ContainsEmoji(gr.Str())
-}

--- a/parse_test.go
+++ b/parse_test.go
@@ -9,45 +9,6 @@ import (
 	"github.com/yuin/goldmark/text"
 )
 
-func TestVariantSpan(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		give         string // input string
-		wantDefault  string // empty for invalid
-		wantObsidian string // empty for invalid
-	}{
-		{give: "", wantDefault: "", wantObsidian: ""},
-		{give: "1a", wantDefault: "", wantObsidian: "1a"},
-		{give: "a", wantDefault: "a", wantObsidian: "a"},
-		{give: "a1", wantDefault: "a1", wantObsidian: "a1"},
-		{give: "foo", wantDefault: "foo", wantObsidian: "foo"},
-		{give: "foo bar", wantDefault: "foo", wantObsidian: "foo"},
-		{give: "éabc d", wantDefault: "éabc", wantObsidian: "éabc"},
-		{give: "✅/🚧", wantDefault: "", wantObsidian: "✅/🚧"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.give, func(t *testing.T) {
-			t.Run("default", func(t *testing.T) {
-				var got string
-				if idx := DefaultVariant.span([]byte(tt.give)); idx >= 0 {
-					got = tt.give[:idx]
-				}
-				assert.Equal(t, tt.wantDefault, got)
-			})
-
-			t.Run("obsidian", func(t *testing.T) {
-				var got string
-				if idx := ObsidianVariant.span([]byte(tt.give)); idx >= 0 {
-					got = tt.give[:idx]
-				}
-				assert.Equal(t, tt.wantObsidian, got)
-			})
-		})
-	}
-}
-
 func TestParser(t *testing.T) {
 	t.Parallel()
 

--- a/render.go
+++ b/render.go
@@ -1,107 +1,21 @@
 package hashtag
 
-import (
-	"fmt"
-	"sync"
-
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/renderer"
-	"github.com/yuin/goldmark/util"
-)
+import "go.abhg.dev/goldmark/hashtag"
 
 // Resolver resolves hashtags to pages they should link to.
-type Resolver interface {
-	// ResolveHashtag reports the link that the provided hashtag Node
-	// should point to, or an empty destination for hashtags that should
-	// not link to anything.
-	ResolveHashtag(*Node) (destination []byte, err error)
-}
+type Resolver = hashtag.Resolver
 
 // Renderer renders hashtag nodes into HTML, optionally linking them to
 // specific pages.
 //
-//  #foo
+//	#foo
 //
 // Renders as the following by default.
 //
-//  <span class="hashtag">#foo</span>
+//	<span class="hashtag">#foo</span>
 //
 // Supply a Resolver that returns a non-empty destination to render it like
 // the following.
 //
-//  <span class="hashtag"><a href="...">#foo</a></span>
-type Renderer struct {
-	// Resolver specifies how where hashtag links should point, if at all.
-	//
-	// When a Resolver returns an empty destination for a hashtag, the
-	// Renderer will render the hashtag as plain text rather than a link.
-	//
-	// Defaults to empty destinations for all hashtags.
-	Resolver Resolver
-
-	once    sync.Once // guards init
-	hasDest map[*Node]struct{}
-}
-
-// RegisterFuncs registers rendering functions from this renderer onto the
-// provided registerer.
-func (r *Renderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
-	reg.Register(Kind, r.Render)
-}
-
-func (r *Renderer) init() {
-	r.once.Do(func() {
-		r.hasDest = make(map[*Node]struct{})
-	})
-}
-
-// Render renders a hashtag node as HTML.
-func (r *Renderer) Render(w util.BufWriter, src []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
-	r.init()
-
-	n, ok := node.(*Node)
-	if !ok {
-		return ast.WalkStop, fmt.Errorf("unexpected node %T, expected *Node", node)
-	}
-
-	if entering {
-		if err := r.enter(w, n); err != nil {
-			return ast.WalkStop, err
-		}
-	} else {
-		r.exit(w, n)
-	}
-
-	return ast.WalkContinue, nil
-}
-
-func (r *Renderer) enter(w util.BufWriter, n *Node) error {
-	w.WriteString(`<span class="hashtag">`)
-
-	var dest []byte
-	if res := r.Resolver; res != nil {
-		var err error
-		dest, err = res.ResolveHashtag(n)
-		if err != nil {
-			return fmt.Errorf("resolve hashtag %q: %w", n.Tag, err)
-		}
-	}
-
-	if len(dest) == 0 {
-		return nil
-	}
-
-	r.hasDest[n] = struct{}{}
-	w.WriteString(`<a href="`)
-	w.Write(util.URLEscape(dest, true /* resolve references */))
-	w.WriteString(`">`)
-	return nil
-}
-
-func (r *Renderer) exit(w util.BufWriter, n *Node) {
-	if _, ok := r.hasDest[n]; ok {
-		delete(r.hasDest, n)
-		w.WriteString("</a>")
-	}
-	w.WriteString("</span>")
-}
+//	<span class="hashtag"><a href="...">#foo</a></span>
+type Renderer = hashtag.Renderer


### PR DESCRIPTION
Turn the v0.2 release into a shim around v0.3
which uses a different import path.
