### PR TITLE
Option to add attributes to <a> tag

### DIFF
--- a/extend.go
+++ b/extend.go
@@ -33,6 +33,13 @@ type Extender struct {
 	// Defaults to DefaultVariant. See the documentation of individual
 	// variants for more information.
 	Variant Variant
+
+	// Attributes are added to the <a> tag.
+	//
+	// Attributes are no escaped and must be valid attributes and values for HTML tags.
+	// Attributes will only be applied if the tag can be resolved by the Resolver.
+	// Defaults to no attributes.
+	Attributes []Attribute
 }
 
 var _ goldmark.Extender = (*Extender)(nil)
@@ -50,7 +57,8 @@ func (e *Extender) Extend(m goldmark.Markdown) {
 	m.Renderer().AddOptions(
 		renderer.WithNodeRenderers(
 			util.Prioritized(&Renderer{
-				Resolver: e.Resolver,
+				Resolver:   e.Resolver,
+				Attributes: e.Attributes,
 			}, 999),
 		),
 	)

--- a/extend.go
+++ b/extend.go
@@ -36,7 +36,6 @@ type Extender struct {
 
 	// Attributes are added to the <a> tag.
 	//
-	// Attributes are no escaped and must be valid attributes and values for HTML tags.
 	// Attributes will only be applied if the tag can be resolved by the Resolver.
 	// Defaults to no attributes.
 	Attributes []Attribute

--- a/integration_test.go
+++ b/integration_test.go
@@ -45,7 +45,7 @@ func TestIntegration_Attributes(t *testing.T) {
 			Resolver: almostAlwaysResolver{},
 			Attributes: []hashtag.Attribute{
 				{
-					Attr:  "class",
+					Name:  "class",
 					Value: "p-category",
 				},
 			},

--- a/integration_test.go
+++ b/integration_test.go
@@ -37,6 +37,21 @@ func TestIntegration_Resolver(t *testing.T) {
 		})))
 }
 
+func TestIntegration_Attributes(t *testing.T) {
+	t.Parallel()
+
+	testIntegration(t, "attributes.yaml",
+		goldmark.New(goldmark.WithExtensions(&hashtag.Extender{
+			Resolver: almostAlwaysResolver{},
+			Attributes: []hashtag.Attribute{
+				{
+					Attr:  "class",
+					Value: "p-category",
+				},
+			},
+		})))
+}
+
 func testIntegration(t *testing.T, file string, md goldmark.Markdown) {
 	testsdata, err := os.ReadFile(filepath.Join("testdata", file))
 	require.NoError(t, err)

--- a/render.go
+++ b/render.go
@@ -46,11 +46,11 @@ type Renderer struct {
 
 // Attribute defines an attribute to be added to an HTML tag.
 //
-// Attribute{ Attr: "class", Value: "tag"}
+//	Attribute{ Attr: "class", Value: "tag"}
 //
 // Will result in <a class="tag" ...>
 type Attribute struct {
-	Attr  string
+	Name  string
 	Value string
 }
 
@@ -97,9 +97,9 @@ func (r *Renderer) enter(w util.BufWriter, n *Node) error {
 	r.hasDest.Store(n, struct{}{})
 	_, _ = w.WriteString(`<a `)
 	for _, attr := range r.Attributes {
-		_, _ = w.WriteString(attr.Attr)
+		_, _ = w.WriteString(attr.Name)
 		_, _ = w.WriteString(`="`)
-		_, _ = w.WriteString(attr.Value)
+		_, _ = w.Write(util.EscapeHTML([]byte(attr.Value)))
 		_, _ = w.WriteString(`" `)
 	}
 	_, _ = w.WriteString(`href="`)

--- a/render.go
+++ b/render.go
@@ -39,7 +39,19 @@ type Renderer struct {
 	// Defaults to empty destinations for all hashtags.
 	Resolver Resolver
 
+	Attributes []Attribute
+
 	hasDest sync.Map // *Node => struct{}
+}
+
+// Attribute defines an attribute to be added to an HTML tag.
+//
+// Attribute{ Attr: "class", Value: "tag"}
+//
+// Will result in <a class="tag" ...>
+type Attribute struct {
+	Attr  string
+	Value string
 }
 
 // RegisterFuncs registers rendering functions from this renderer onto the
@@ -83,7 +95,14 @@ func (r *Renderer) enter(w util.BufWriter, n *Node) error {
 	}
 
 	r.hasDest.Store(n, struct{}{})
-	_, _ = w.WriteString(`<a href="`)
+	_, _ = w.WriteString(`<a `)
+	for _, attr := range r.Attributes {
+		_, _ = w.WriteString(attr.Attr)
+		_, _ = w.WriteString(`="`)
+		_, _ = w.WriteString(attr.Value)
+		_, _ = w.WriteString(`" `)
+	}
+	_, _ = w.WriteString(`href="`)
 	_, _ = w.Write(util.URLEscape(dest, true /* resolve references */))
 	_, _ = w.WriteString(`">`)
 	return nil

--- a/testdata/attributes.yaml
+++ b/testdata/attributes.yaml
@@ -1,0 +1,5 @@
+- name: simple
+  give: |
+    Foo #bar # baz.
+  want: |
+    <p>Foo <span class="hashtag"><a class="p-category" href="/tag/bar">#bar</a></span> # baz.</p>


### PR DESCRIPTION
I wanted to add classes to the `<a>` tag in order to implement microformats (adding `class="p-category"`)

Implementation:

* Defined `Attribute` struct holding attribute name and value
* Added `Attributes` to `Extender` as list of attributes
* Renderer takes list of attributes to be rendered